### PR TITLE
upgrade growl to 1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4326,8 +4326,8 @@
       "dev": true
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
@@ -5808,7 +5808,7 @@
         "diff": "1.4.0",
         "escape-string-regexp": "1.0.2",
         "glob": "3.2.11",
-        "growl": "1.9.2",
+        "growl": "1.10.2",
         "jade": "0.26.3",
         "mkdirp": "0.5.1",
         "supports-color": "1.2.0",


### PR DESCRIPTION
Upgrading package lock file growl from 1.9.2 to 1.10.2